### PR TITLE
⚡ Bolt: Fix N+1 query bottleneck in admin dashboard

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-28 - N+1 Bottlenecks in Dashboard
+**Learning:** The dashboard endpoints perform massive N+1 queries when loading clients and client executions for all visible experiments inside nested loops, causing severe performance degradation.
+**Action:** Always batch fetch related records using `.in_()` and map them in memory using `collections.defaultdict` when aggregating nested data structures like experiments -> clients -> executions.

--- a/y_web/routes/admin/dashboard.py
+++ b/y_web/routes/admin/dashboard.py
@@ -211,6 +211,7 @@ def dashboard():
 
         # Group clients by experiment ID
         from collections import defaultdict
+
         clients_by_exp = defaultdict(list)
         client_ids = []
         for client in all_clients:
@@ -220,7 +221,9 @@ def dashboard():
         # Batch fetch all client executions
         executions_by_client = {}
         if client_ids:
-            all_executions = Client_Execution.query.filter(Client_Execution.client_id.in_(client_ids)).all()
+            all_executions = Client_Execution.query.filter(
+                Client_Execution.client_id.in_(client_ids)
+            ).all()
             for execution in all_executions:
                 executions_by_client[execution.client_id] = execution
 
@@ -411,6 +414,7 @@ def dashboard_experiments_by_status(status):
 
         # Group clients by experiment ID
         from collections import defaultdict
+
         clients_by_exp = defaultdict(list)
         client_ids = []
         for client in all_clients:
@@ -420,7 +424,9 @@ def dashboard_experiments_by_status(status):
         # Batch fetch all client executions
         executions_by_client = {}
         if client_ids:
-            all_executions = Client_Execution.query.filter(Client_Execution.client_id.in_(client_ids)).all()
+            all_executions = Client_Execution.query.filter(
+                Client_Execution.client_id.in_(client_ids)
+            ).all()
             for execution in all_executions:
                 executions_by_client[execution.client_id] = execution
 

--- a/y_web/routes/admin/dashboard.py
+++ b/y_web/routes/admin/dashboard.py
@@ -200,11 +200,36 @@ def dashboard():
     # Helper function to build experiment data with clients
     def build_experiment_data(experiments_list):
         result = {}
+        if not experiments_list:
+            return result
+
+        # Get all experiment IDs
+        exp_ids = [e.idexp for e in experiments_list]
+
+        # Batch fetch all clients for these experiments
+        all_clients = Client.query.filter(Client.id_exp.in_(exp_ids)).all()
+
+        # Group clients by experiment ID
+        from collections import defaultdict
+        clients_by_exp = defaultdict(list)
+        client_ids = []
+        for client in all_clients:
+            clients_by_exp[client.id_exp].append(client)
+            client_ids.append(client.id)
+
+        # Batch fetch all client executions
+        executions_by_client = {}
+        if client_ids:
+            all_executions = Client_Execution.query.filter(Client_Execution.client_id.in_(client_ids)).all()
+            for execution in all_executions:
+                executions_by_client[execution.client_id] = execution
+
+        # Build the final result
         for e in experiments_list:
-            clients = Client.query.filter_by(id_exp=e.idexp).all()
+            clients = clients_by_exp.get(e.idexp, [])
             client_data = []
             for client in clients:
-                cl = Client_Execution.query.filter_by(client_id=client.id).first()
+                cl = executions_by_client.get(client.id)
                 client_executions = cl if cl is not None else -1
                 client_data.append((client, client_executions))
             result[e.idexp] = {"experiment": e, "clients": client_data}
@@ -376,11 +401,34 @@ def dashboard_experiments_by_status(status):
 
     # Build experiment data with clients
     result = []
+
+    if paginated_experiments:
+        # Get all experiment IDs
+        exp_ids = [exp.idexp for exp in paginated_experiments]
+
+        # Batch fetch all clients for these experiments
+        all_clients = Client.query.filter(Client.id_exp.in_(exp_ids)).all()
+
+        # Group clients by experiment ID
+        from collections import defaultdict
+        clients_by_exp = defaultdict(list)
+        client_ids = []
+        for client in all_clients:
+            clients_by_exp[client.id_exp].append(client)
+            client_ids.append(client.id)
+
+        # Batch fetch all client executions
+        executions_by_client = {}
+        if client_ids:
+            all_executions = Client_Execution.query.filter(Client_Execution.client_id.in_(client_ids)).all()
+            for execution in all_executions:
+                executions_by_client[execution.client_id] = execution
+
     for exp in paginated_experiments:
-        clients = Client.query.filter_by(id_exp=exp.idexp).all()
+        clients = clients_by_exp.get(exp.idexp, [])
         client_data = []
         for client in clients:
-            cl = Client_Execution.query.filter_by(client_id=client.id).first()
+            cl = executions_by_client.get(client.id)
             elapsed = cl.elapsed_time if cl else 0
             expected = cl.expected_duration_rounds if cl else 0
             progress = min(100, int((elapsed / expected) * 100)) if expected > 0 else 0

--- a/y_web/tests/test_client_form_fields.py
+++ b/y_web/tests/test_client_form_fields.py
@@ -183,6 +183,7 @@ class TestClientFormFields:
 
     def test_follow_back_field_is_wired_in_all_client_forms(self):
         import os
+
         base_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 
         templates = [
@@ -191,7 +192,9 @@ class TestClientFormFields:
             os.path.join(base_dir, "y_web", "templates", "admin", "clients_hpc.html"),
         ]
         crud_source = open(
-            os.path.join(base_dir, "y_web", "routes", "admin", "sub", "clients", "_crud.py"),
+            os.path.join(
+                base_dir, "y_web", "routes", "admin", "sub", "clients", "_crud.py"
+            ),
             "r",
         ).read()
 
@@ -203,6 +206,7 @@ class TestClientFormFields:
 
     def test_hpc_follow_defaults_enable_network_growth(self):
         import os
+
         base_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
         template_source = open(
             os.path.join(base_dir, "y_web", "templates", "admin", "clients_hpc.html"),

--- a/y_web/tests/test_client_form_fields.py
+++ b/y_web/tests/test_client_form_fields.py
@@ -182,13 +182,16 @@ class TestClientFormFields:
             pytest.skip(f"Could not import Flask: {e}")
 
     def test_follow_back_field_is_wired_in_all_client_forms(self):
+        import os
+        base_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+
         templates = [
-            "/Users/rossetti/PycharmProjects/YWeb/y_web/templates/admin/clients.html",
-            "/Users/rossetti/PycharmProjects/YWeb/y_web/templates/admin/clients_forum.html",
-            "/Users/rossetti/PycharmProjects/YWeb/y_web/templates/admin/clients_hpc.html",
+            os.path.join(base_dir, "y_web", "templates", "admin", "clients.html"),
+            os.path.join(base_dir, "y_web", "templates", "admin", "clients_forum.html"),
+            os.path.join(base_dir, "y_web", "templates", "admin", "clients_hpc.html"),
         ]
         crud_source = open(
-            "/Users/rossetti/PycharmProjects/YWeb/y_web/routes/admin/sub/clients/_crud.py",
+            os.path.join(base_dir, "y_web", "routes", "admin", "sub", "clients", "_crud.py"),
             "r",
         ).read()
 
@@ -199,8 +202,10 @@ class TestClientFormFields:
         assert crud_source.count("probability_of_follow_back") >= 8
 
     def test_hpc_follow_defaults_enable_network_growth(self):
+        import os
+        base_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
         template_source = open(
-            "/Users/rossetti/PycharmProjects/YWeb/y_web/templates/admin/clients_hpc.html",
+            os.path.join(base_dir, "y_web", "templates", "admin", "clients_hpc.html"),
             "r",
         ).read()
 


### PR DESCRIPTION
💡 **What**: Refactored `build_experiment_data` and `dashboard_data` endpoints to fetch `Client` and `Client_Execution` records in bulk using `.in_()` clauses, grouping them in memory rather than running independent queries inside loops.
🎯 **Why**: The admin dashboard was performing a huge amount of database queries (an N+1 pattern where `N` queries fetch clients for each experiment, and `M` queries fetch executions for each client). This slowed down dashboard loading linearly with the number of active experiments.
📊 **Impact**: Reduces dashboard database queries from O(N * C) to O(1) per category. Drastically improves dashboard page load performance, particularly on instances with a large number of experiments or clients.
🔬 **Measurement**: Verify by inspecting the network load time for `/admin/dashboard` or by profiling SQL requests. The change is fully backwards compatible and was verified by unit tests.

---
*PR created automatically by Jules for task [5842373782745948476](https://jules.google.com/task/5842373782745948476) started by @GiulioRossetti*